### PR TITLE
Support packed tests

### DIFF
--- a/l3build/l3build.dtx
+++ b/l3build/l3build.dtx
@@ -604,6 +604,10 @@
 %   \item Correction of a \LuaTeX{} error message typo (|I''m going to assume|).
 % \end{itemize}
 %
+% \subsection{Generating test files with docstrip}
+%
+% It is also possible to pack tests and goals in \texttt{.dtx} files. If a test specification (\texttt{.lvt}) or goal (\texttt{.ltg}) shows up during the usual unpacking process that starts most of the command, it will be considered with the \texttt{check} and \texttt{save} commands as if it was found in the \texttt{testfiledir}. Be aware that this means that a test goal there may shadow a generated one of the same name. When performing test related tasks, the \texttt{testfiledir} will also be searched for \texttt{sourcefiles} to unpack. These will not be relevant to other commands, especially they will not show up in the archives created for the \texttt{ctan}.
+%
 % \section{Writing test files}
 % \label{sec:writing-tests}
 %

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -674,7 +674,9 @@ end
 -- Run one of the test files: doesn't check the result so suitable for
 -- both creating and verifying .tlg files
 function runtest (name, engine, hide)
-  cp (name .. lvtext, testfiledir, testdir)
+  local lvtfile = name .. lvtext
+  cp (lvtfile, fileexists (testfiledir .. "/" .. lvtfile)
+    and testfiledir or unpackdir, testdir)
   local engine = engine or stdengine
   -- Set up the format file name if it's one ending "...tex"
   local format
@@ -684,7 +686,6 @@ function runtest (name, engine, hide)
     format = ""
   end
   local logfile = testdir .. "/" .. name .. logext
-  local lvtfile = name .. lvtext
   local newfile = testdir .. "/" .. name .. "." .. engine .. logext
   for i = 1, checkruns, 1 do
     run (

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -652,9 +652,11 @@ function runcheck (name, engine, hide)
     local difffile = testdir .. "/" .. testname .. os_diffext
     local newfile  = testdir .. "/" .. testname .. logext
     -- Use engine-specific file if available
-    local tlgfile  = testfiledir .. "/" .. name ..  "." .. i .. tlgext
-    if not fileexists (tlgfile) then
-      tlgfile  = testfiledir .. "/" .. name .. tlgext
+    local tlgfile  = locate({testfiledir, unpackdir},
+      {name ..  "." .. i .. tlgext, name ..tlgext})
+    if not tlgfile then
+      print ("unable to find test goal for " .. name)
+      tlgfile = os_null
     end
     if os_windows then
       tlgfile = unix_to_win (tlgfile)

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -1086,6 +1086,9 @@ function save (name, engine)
     runtest (name, engine, false)
     ren (testdir, newfile, tlgfile)
     cp (tlgfile, testdir, testfiledir)
+    if fileexists (unpackdir .. "/" .. tlgfile) then
+      print ("This masks an unpacked test goal of the same name")
+    end
   else
     print (
       "Test input \"" .. testfiledir .. "/" .. name .. lvtext ..

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -804,8 +804,8 @@ function checkall ()
 end
 
 function checklvt (name, engine)
+  checkinit ()
   if testexists (name) then
-    checkinit ()
     print ("Running checks on " .. name)
     local errorlevel = runcheck (name, engine)
     if errorlevel ~= 0 then
@@ -1078,10 +1078,10 @@ function install ()
 end
 
 function save (name, engine)
+  checkinit ()
   local tlgfile = name .. (engine and ("." .. engine) or "") .. tlgext
   local newfile = name .. "." .. (engine or stdengine) .. logext
   if testexists (name) then
-    checkinit ()
     print ("Creating and copying " .. tlgfile)
     runtest (name, engine, false)
     ren (testdir, newfile, tlgfile)

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -719,7 +719,8 @@ function stripext (file)
 end
 
 function testexists (test)
-  if fileexists (testfiledir .. "/" .. test .. lvtext) then
+  if fileexists (testfiledir .. "/" .. test .. lvtext) or
+    fileexists(unpackdir .. "/" .. test .. lvtext) then
     return true
   else
     return false

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -718,13 +718,21 @@ function stripext (file)
   return name or file
 end
 
-function testexists (test)
-  if fileexists (testfiledir .. "/" .. test .. lvtext) or
-    fileexists(unpackdir .. "/" .. test .. lvtext) then
-    return true
-  else
-    return false
+-- Look for filenames, directory by directory, and return the first existing.
+function locate (directories, filenames)
+  for _, directory in ipairs (directories) do
+    for _, filename in ipairs (filenames) do
+      local path = directory .. "/" .. filename
+      if fileexists (path) then
+        return path
+      end
+    end
   end
+  return nil
+end
+
+function testexists (test)
+  return locate ({testfiledir, unpackdir}, {test .. lvtext})
 end
 
 -- Standard versions of the main targets for building modules

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -1070,7 +1070,7 @@ end
 function save (name, engine)
   local tlgfile = name .. (engine and ("." .. engine) or "") .. tlgext
   local newfile = name .. "." .. (engine or stdengine) .. logext
-  if fileexists (testfiledir .. "/" .. name .. lvtext) then
+  if testexists (name) then
     checkinit ()
     print ("Creating and copying " .. tlgfile)
     runtest (name, engine, false)

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -770,13 +770,19 @@ function checkall ()
   if testfiledir ~= "" and direxists (testfiledir) then
     checkinit ()
     print ("Running checks on")
-    for _,i in ipairs (filelist (testfiledir, "*" .. lvtext)) do
+    function execute(i)
       local name = stripext (i)
       print ("  " .. name)
       local errlevel = runcheck (name, nil, true)
       if errlevel ~= 0 then
         errorlevel = 1
       end
+    end
+    for _,i in ipairs (filelist (testfiledir, "*" .. lvtext)) do
+      execute(i)
+    end
+    for _,i in ipairs (filelist (unpackdir, "*" .. lvtext)) do
+      execute(i)
     end
     if errorlevel ~= 0 then
       checkdiff ()

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -403,7 +403,7 @@ function checkinit ()
   for _,i in ipairs (filelist (localdir)) do
     cp (i, localdir, testdir)
   end
-  bundleunpack ()
+  bundleunpack ({".", testfiledir})
   for _,i in ipairs (installfiles) do
     cp (i, unpackdir, testdir)
   end
@@ -1109,11 +1109,14 @@ end
 
 -- Split off from the main unpack so it can be used on a bundle and not
 -- leave only one modules files
-function bundleunpack ()
+function bundleunpack (sourcedir)
   mkdir (localdir)
   cleandir (unpackdir)
-  for _,i in ipairs (sourcefiles) do
-    cp (i, ".", unpackdir)
+  for _,i in ipairs (sourcedir or {"."}) do
+    for _,j in ipairs (sourcefiles) do
+      print(j, i, unpackdir)
+      cp (j, i, unpackdir)
+    end
   end
   for _,i in ipairs (unpacksuppfiles) do
     cp (i, supportdir, localdir)

--- a/l3build/testfiles/01-packed.ins
+++ b/l3build/testfiles/01-packed.ins
@@ -1,0 +1,12 @@
+\input docstrip.tex
+\usepreamble\empty
+\usepostamble\empty
+\generate{
+  \file{01-packed-1.lvt}{\from{01-tests.dtx}{step}}
+  \file{01-packed-2.lvt}{\from{01-tests.dtx}{lognewcounter,set}}
+  \file{01-packed-1.tlg}{\from{01-results.dtx}{}}
+  \file{01-packed-1.xetex.tlg}{\from{01-results.dtx}{xetex}}
+  \file{01-packed-2.tlg}{\from{01-results.dtx}{2}}
+  \file{01-packed-2.xetex.tlg}{\from{01-results.dtx}{2,xetex}}
+}
+\endbatchfile

--- a/l3build/testfiles/01-results.dtx
+++ b/l3build/testfiles/01-results.dtx
@@ -1,0 +1,21 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+%% \CharacterTable
+%%  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
+%%   Lower-case    \a\b\c\d\e\f\g\h\i\j\k\l\m\n\o\p\q\r\s\t\u\v\w\x\y\z
+%%   Digits        \0\1\2\3\4\5\6\7\8\9
+%%   Exclamation   \!     Double quote  \"     Hash (number) \#
+%%   Dollar        \$     Percent       \%     Ampersand     \&
+%%   Acute accent  \'     Left paren    \(     Right paren   \)
+%%   Asterisk      \*     Plus          \+     Comma         \,
+%%   Minus         \-     Point         \.     Solidus       \/
+%%   Colon         \:     Semicolon     \;     Less than     \<
+%%   Equals        \=     Greater than  \>     Question mark \?
+%%   Commercial at \@     Left bracket  \[     Backslash     \\
+%%   Right bracket \]     Circumflex    \^     Underscore    \_
+%%   Grave accent  \`     Left brace    \{     Vertical bar  \|
+%%   Right brace   \}     Tilde         \~}
+%%
+%<2&!xetex>\c@c=\count112
+%<2&xetex>\c@c=\count113
+5

--- a/l3build/testfiles/01-tests.dtx
+++ b/l3build/testfiles/01-tests.dtx
@@ -1,0 +1,10 @@
+\input regression-test.tex
+\begin{document}
+%<!lognewcounter>\newcounter{c}
+\START
+%<lognewcounter>\newcounter{c}
+%<set>\setcounter{c}{5}
+%<step>\setcounter{c}{4}
+%<step>\stepcounter{c}
+\typeout{\thec}
+\END


### PR DESCRIPTION
Some developers may write their tests in the docstrip format, for example to unify common setup code for multiple tests. ([You may look at a simple exemplary use case here.](https://github.com/dffischer/l3build-testingtests)) 

`l3build.lua` does currently support this quite poorly. `testfiledir` can be set to `unoackdir` to make generated `lvt` files be found, but then `build.lua save` stores the `tlg`s into `unpackdir` where they are soon to be deleted.

This patch looks for `lvt`s in `unpackdir`, too, but still stores `tlg`s into `testfiledir`, where they persist.

I read that you do not apply patches directly at github. If you favor to receive this patch in any other way, please leave a comment.