### PR TITLE
remove line numbers when \showing boxes

### DIFF
--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -553,8 +553,8 @@ function formatlog (logfile, newfile)
     line = string.gsub (line, "\\csname\\endcsname ", "\\csname\\endcsname")
     -- Zap "on line <num>" and replace with "on line ..."
     line = string.gsub (line, "on line %d*", "on line ...")
-    -- Zap line numbers from \show, \showbox and the like
-    line = string.gsub (line, "^l.%d* \\show", "l. ... \\show")
+    -- Zap line numbers from \show, \showbox, \box_show and the like
+    line = string.gsub (line, "^l.%d* (\\[^ ]*show)", "l. ... %1")
     -- Remove spaces at the start of lines: deals with the fact that LuaTeX
     -- uses a different number to the other engines
     line = string.gsub (line, "^%s+", "")

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -553,6 +553,8 @@ function formatlog (logfile, newfile)
     line = string.gsub (line, "\\csname\\endcsname ", "\\csname\\endcsname")
     -- Zap "on line <num>" and replace with "on line ..."
     line = string.gsub (line, "on line %d*", "on line ...")
+    -- Zap line numbers from \show, \showbox and the like
+    line = string.gsub (line, "^l.%d* \\show", "l. ... \\show")
     -- Remove spaces at the start of lines: deals with the fact that LuaTeX
     -- uses a different number to the other engines
     line = string.gsub (line, "^%s+", "")


### PR DESCRIPTION
The manual suggests checking typeset output by placing it into a box and then `\showbox` its content. The output will then include a number denoting at which line of the `lvt` source the command was issued. This could mess up comparison and should be removed analogous to `on line ...` is. The attached patch fixes this by replacing the line number with `...` like it is already done with other numbers.