### PR TITLE
handle hyphenated test file names

### DIFF
--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -699,7 +699,8 @@ function runtest (name, engine, hide)
     local ext = string.match (i, "%....")
     if ext ~= lvtext and ext ~= tlgext and ext ~= logext then
       if not fileexists (testsuppdir .. "/" .. i) then
-        ren (testdir, i, string.gsub (i, name, name .. "." .. engine ))
+        ren (testdir, i, string.gsub (i,
+          string.gsub(name, "%-", "%%-"), name .. "." .. engine ))
       end
     end
   end


### PR DESCRIPTION
When trying to execute the tests for l3build, I noticed that test file names with dashes cause errors. This is because they have to pass through lua's `string.gsub` as a pattern where the dash is a special symbol. Escaping it solves this problem.