### PR TITLE
support expectation tests

### DIFF
--- a/l3build/l3build.dtx
+++ b/l3build/l3build.dtx
@@ -112,6 +112,7 @@
 \luavarset{lvtext} {".lvt"} {Extension of test files.}
 \luavarset{tlgext} {".tlg"} {Extension of test file output.}
 \luavarset{logext} {".log"} {Extension of checking output, before processing it into a \texttt{.tlg}.}
+\luavarset{lveext} {".lve"} {Extension of expextation files. Missing \texttt{.tlg} files will be generated from them.}
 \luavarseparator
 \luavarset{checkdeps}   {\{~\}} {List of build unpack dependencies for checking.}
 \luavarset{typesetdeps} {\{~\}} {\dots for typesetting docs.}
@@ -806,6 +807,10 @@
 %   \caption{Output from displaying the contents of a simple box to the log file, using plain \TeX{} (left) and \pkg{expl3} (right). Some blank lines have been added to the plain \TeX{} version to help with the comparison.}
 %   \label{fig:box-log}
 % \end{figure}
+%
+% \subsection{Specifying expectations}
+%
+% Regression tests check whether changes introduced in the code modify the test output. Especially while developing a complex package there is not yet a baseline to save a test goal with. It might then be easier to formulate the expected effects and outputs of tests directly. To achieve this, you may create an \texttt{.lve} instead of a \texttt{.tlg} file.\footnote{Mnemonic: \texttt{lv\textbf{t}}: \textbf{t}est, \texttt{lv\textbf{e}}: \textbf{e}xpectation} It is processed exactly like the \texttt{.lvt} to generate the expected outcome. The test fails when both differ.
 %
 %
 %

--- a/l3build/l3build.dtx
+++ b/l3build/l3build.dtx
@@ -605,14 +605,6 @@
 %   \item Correction of a \LuaTeX{} error message typo (|I''m going to assume|).
 % \end{itemize}
 %
-% \subsection{Generating test files with \pkkg{DocStrip}}
-%
-% It is  possible to pack tests inside source files. Tests generated during the
-% unpacking process will be available to the \texttt{check} and \texttt{save}
-% commands as if they were stored in the \texttt{testfiledir}. Any explicit
-% test files inside \texttt{testfiledir} take priority over generated ones
-% with the same names.
-%
 % \section{Writing test files}
 % \label{sec:writing-tests}
 %
@@ -807,6 +799,15 @@
 %   \caption{Output from displaying the contents of a simple box to the log file, using plain \TeX{} (left) and \pkg{expl3} (right). Some blank lines have been added to the plain \TeX{} version to help with the comparison.}
 %   \label{fig:box-log}
 % \end{figure}
+%
+% \section{Alternative test formats}
+% \subsection{Generating test files with \pkkg{DocStrip}}
+%
+% It is  possible to pack tests inside source files. Tests generated during the
+% unpacking process will be available to the \texttt{check} and \texttt{save}
+% commands as if they were stored in the \texttt{testfiledir}. Any explicit
+% test files inside \texttt{testfiledir} take priority over generated ones
+% with the same names.
 %
 % \subsection{Specifying expectations}
 %

--- a/l3build/l3build.dtx
+++ b/l3build/l3build.dtx
@@ -813,6 +813,39 @@
 %
 % Regression tests check whether changes introduced in the code modify the test output. Especially while developing a complex package there is not yet a baseline to save a test goal with. It might then be easier to formulate the expected effects and outputs of tests directly. To achieve this, you may create an \texttt{.lve} instead of a \texttt{.tlg} file.\footnote{Mnemonic: \texttt{lv\textbf{t}}: \textbf{t}est, \texttt{lv\textbf{e}}: \textbf{e}xpectation} It is processed exactly like the \texttt{.lvt} to generate the expected outcome. The test fails when both differ.
 %
+% Combining both features enables contrasting the test with its expected outcome in a compact format. Listing \ref{fig:expect-dtx} exemplary tests \TeX{}s counters. Listing \ref{fig:expect-ins} shows the relevant part of an \texttt{.ins} file to generate it.
+%
+% \begin{figure}
+%   \begin{lstlisting}[frame=single,language={TeX},gobble = 6]
+%     \input regression-test.tex\relax
+%     \START
+%     \TEST{counter-math}{
+%     %<*test>
+%       \OMIT
+%       \newcounter{numbers}
+%       \setcounter{numbers}{2}
+%       \addtocounter{numbers}{2}
+%       \stepcounter{numbers}
+%       \TIMO
+%       \typeout{\arabic{numbers}}
+%     %</test>
+%     %<expect>  \typeout{5}
+%     }
+%     \END
+%   \end{lstlisting}
+%   \caption{Test and expectation can be specified side-by-side in a single \texttt{.dtx} file.}
+%   \label{fig:expect-dtx}
+% \end{figure}
+%
+%\begin{figure}
+%   \begin{lstlisting}[frame=single,language={TeX},gobble = 6]
+%      \generate{\file{\jobname.lvt}{\from{\jobname.dtx}{test}}
+%                \file{\jobname.lve}{\from{\jobname.dtx}{expect}}}
+%   \end{lstlisting}
+%   \caption{Test and expectation are generated from a \texttt{.dtx} file of the same name.}
+%   \label{fig:expect-ins}
+% \end{figure}
+%
 %
 %
 %

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -666,7 +666,7 @@ function runcheck (name, engine, hide)
     -- Use engine-specific file if available
     local tlgfile  = locate (
       {testfiledir, unpackdir},
-      {name ..  "." .. i .. tlgext, name .. tlgext}
+      {testname .. tlgext, name .. tlgext}
     )
     if not tlgfile then
       print ("Error: failed to find " .. tlgext .. " file for " .. name .. "!")

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -667,11 +667,21 @@ function runcheck (name, engine, hide)
       {testfiledir, unpackdir},
       {testname .. tlgext, name .. tlgext}
     )
-    if not tlgfile then
-      print ("Error: failed to find " .. tlgext .. " file for " .. name .. "!")
-      os.exit (1)
+    if tlgfile then
+      cp (name .. tlgext, testfiledir, testdir)
+    else
+      -- generate missing test goal from expectation
+      tlgfile = testdir .. "/" .. testname .. tlgext
+      if not locate ({unpackdir, testfiledir}, {name .. lveext}) then
+        print (
+          "Error: failed to find " .. tlgext .. " or "
+          .. lveext .. " file for " .. name .. "!"
+        )
+        os.exit (1)
+      end
+      runtest(name, i, hide, lveext)
+      ren(testdir, testname .. logext, testname .. tlgext)
     end
-    cp (name .. tlgext, testfiledir, testdir)
     runtest (name, i, hide, lvtext)
     -- compare test result with goal
     if os_windows then

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -143,6 +143,7 @@ typesetcmds = typesetcmds or ""
 logext = logext or ".log"
 lvtext = lvtext or ".lvt"
 tlgext = tlgext or ".tlg"
+lveext = lveext or ".lve"
 
 -- Convert a file glob into a pattern for use by e.g. string.gub
 -- Based on https://github.com/davidm/lua-glob-pattern
@@ -716,7 +717,8 @@ function runtest (name, engine, hide, ext)
   -- Store secondary files for this engine
   for _,i in ipairs (filelist (testdir, name .. ".???")) do
     local ext = string.match (i, "%....")
-    if ext ~= lvtext and ext ~= tlgext and ext ~= logext then
+    if ext ~= lvtext and ext ~= tlgext and
+      ext ~= lveext and ext ~= logext then
       if not fileexists (testsuppdir .. "/" .. i) then
         ren (
           testdir, i, string.gsub (

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -1112,6 +1112,11 @@ function save (name, engine)
         "Saved " .. tlgext
           .. " file overrides unpacked version of the same name"
       )
+    elseif locate({unpackdir, testfiledir}, {name .. lveext}) then
+      print (
+        "Saved " .. tlgext .. " file overrides a "
+        .. lveext .. " file of the same name"
+      )
     end
   else
     print (

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -659,7 +659,7 @@ function runcheck (name, engine, hide)
   local errorlevel = 0
   for _,i in ipairs (checkengines) do
     cp (name .. tlgext, testfiledir, testdir)
-    runtest (name, i, hide)
+    runtest (name, i, hide, lvtext)
     local testname = name .. "." .. i
     local difffile = testdir .. "/" .. testname .. os_diffext
     local newfile  = testdir .. "/" .. testname .. logext
@@ -689,8 +689,8 @@ end
 
 -- Run one of the test files: doesn't check the result so suitable for
 -- both creating and verifying .tlg files
-function runtest (name, engine, hide)
-  local lvtfile = name .. lvtext
+function runtest (name, engine, hide, ext)
+  local lvtfile = name .. (ext or lvtext)
   cp (lvtfile, fileexists (testfiledir .. "/" .. lvtfile)
     and testfiledir or unpackdir, testdir)
   local engine = engine or stdengine
@@ -1091,7 +1091,7 @@ function save (name, engine)
   checkinit ()
   if testexists (name) then
     print ("Creating and copying " .. tlgfile)
-    runtest (name, engine, false)
+    runtest (name, engine, false, lvtext)
     ren (testdir, newfile, tlgfile)
     cp (tlgfile, testdir, testfiledir)
     if fileexists (unpackdir .. "/" .. tlgfile) then

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -659,8 +659,6 @@ function runcheck (name, engine, hide)
   end
   local errorlevel = 0
   for _,i in ipairs (checkengines) do
-    cp (name .. tlgext, testfiledir, testdir)
-    runtest (name, i, hide, lvtext)
     local testname = name .. "." .. i
     local difffile = testdir .. "/" .. testname .. os_diffext
     local newfile  = testdir .. "/" .. testname .. logext
@@ -673,6 +671,9 @@ function runcheck (name, engine, hide)
       print ("Error: failed to find " .. tlgext .. " file for " .. name .. "!")
       os.exit (1)
     end
+    cp (name .. tlgext, testfiledir, testdir)
+    runtest (name, i, hide, lvtext)
+    -- compare test result with goal
     if os_windows then
       tlgfile = unix_to_win (tlgfile)
     end


### PR DESCRIPTION
l3build is focused around regression tests, i.e. evaluating test output by comparing with a previous output defined as correct. Especially when testing typeset output, boxes or other complex matter, the test goals are not intuitive to read. It can often be easier to write and comprehend expectation tests, that is specifying test content and expected result in the same format. The patches proposed herein make it possible to alternatively specify expected results in the same format as tests. If such an expectation specification (`.lve`) is present, the `.tlg` is generated from it. The test passes when both `.lvt` and `.lve` lead to the same output, after processing by the usual log formatting.

You can look at an example in a [further branch](https://github.com/dffischer/svn-mirror/blob/expect-packed/l3build/testfiles/01-expect.dtx) showing test and expectation side-by-side in a `dtx` file, which provides a clean format to use thanks to b6b38b0412f0d96283db83e78203da77aa18640d.