### PR TITLE
support biblatex

### DIFF
--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -1021,8 +1021,7 @@ function doc ()
       end
     end
     local function typeset (file)
-      local errorlevel =
-        os.execute (
+      return os.execute (
             os_setenv .. " TEXINPUTS=" .. typesetdir .. 
               os_pathsep .. localdir .. (typesetsearch and os_pathsep or "") ..
               os_concat ..
@@ -1031,7 +1030,6 @@ function doc ()
               " \"" .. typesetcmds .. 
               "\\input " .. typesetdir .. "/" .. file .. "\""
           )
-      return errorlevel
     end
     os.remove (name .. ".pdf")
     print ("Typesetting " .. name)

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -1031,6 +1031,12 @@ function doc ()
               "\\input " .. typesetdir .. "/" .. file .. "\""
           )
     end
+    local function biber (file)
+      return os.execute (
+        "biber --input-directory " .. localdir
+        .. " " .. typesetdir .. "/" .. name
+      )
+    end
     os.remove (name .. ".pdf")
     print ("Typesetting " .. name)
     local errorlevel = typeset (file)
@@ -1040,6 +1046,9 @@ function doc ()
     else
       makeindex (name, ".glo", ".gls", ".glg", glossarystyle)
       makeindex (name, ".idx", ".ind", ".ilg", indexstyle)
+      if fileexists (typesetdir .. "/" .. name .. ".bcf") then
+        biber (name)
+      end
       typeset (file)
       typeset (file)
       cp (name .. ".pdf", typesetdir, ".")


### PR DESCRIPTION
Some authors may want to put citations into their documentation, but `l3build` currently has no support for bibliographies in manuals.

This patch automatically runs `biber` in between typeset runs when needed.

I stuck to `biblatex` with the `biber` backend only, because their need is clearly indicated whenever a `.bcf` file is present. Checking for the need to `bibtex` is more difficult, as its directives hide in the the `.aux` file.