### PR TITLE
ignore all line numbers at the start of log lines

### DIFF
--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -554,7 +554,7 @@ function formatlog (logfile, newfile)
     -- Zap "on line <num>" and replace with "on line ..."
     line = string.gsub (line, "on line %d*", "on line ...")
     -- Zap line numbers from \show, \showbox, \box_show and the like
-    line = string.gsub (line, "^l.%d* (\\[^ ]*show)", "l. ... %1")
+    line = string.gsub (line, "^l.%d*", "l. ...")
     -- Remove spaces at the start of lines: deals with the fact that LuaTeX
     -- uses a different number to the other engines
     line = string.gsub (line, "^%s+", "")


### PR DESCRIPTION
Recently, I had to test error messages with l3build and found that they also include line numbers that interfere with the comparison of `.tlg` files. Commit 7abddccc8569af0140bda59585637dbc10e8a9fb does not suffice to remove them, so I modified the regular expression introduced therein to universally catch line numbers at the start of lines.